### PR TITLE
añadir banco de preguntas editable para TeidesatKids

### DIFF
--- a/addons/teidesat_website/__init__.py
+++ b/addons/teidesat_website/__init__.py
@@ -1,1 +1,2 @@
 from . import controllers
+from . import models

--- a/addons/teidesat_website/__manifest__.py
+++ b/addons/teidesat_website/__manifest__.py
@@ -5,6 +5,8 @@
     'category': 'Website',
     'depends': ['website'],
     'data': [
+        'security/ir.model.access.csv',
+        'views/teidesatkids_question_views.xml',
         'views/pages/home.xml',
         'views/pages/divulgacion.xml',
         'views/pages/nosotros.xml',

--- a/addons/teidesat_website/controllers/main.py
+++ b/addons/teidesat_website/controllers/main.py
@@ -1,5 +1,6 @@
 from odoo import http
 from odoo.http import request
+import json
 
 
 class TeidesatWebsite(http.Controller):
@@ -63,6 +64,34 @@ class TeidesatWebsite(http.Controller):
     @http.route('/departamentos/electrocom', type='http', auth='public', website=True)
     def departamento_electrocom(self, **kwargs):
         return request.render('teidesat_website.page_departamento_electrocom')
+    
+    @http.route("/teidesatkids/questions", type="http", auth="public", website=True, methods=["GET"], csrf=False)
+    def teidesatkids_questions(self, **kwargs):
+        questions = request.env["teidesat.kids.question"].sudo().search([
+            ("active", "=", True)
+        ])
+
+        result = []
+
+        for q in questions:
+            result.append({
+                "question": q.name,
+                "options": [
+                    q.answer_1,
+                    q.answer_2,
+                    q.answer_3
+                ],
+                "correct": int(q.correct_answer),
+                "category": q.category or "",
+                "difficulty": q.difficulty or "easy"
+            })
+
+        return request.make_response(
+            json.dumps(result, ensure_ascii=False),
+            headers=[
+                ("Content-Type", "application/json; charset=utf-8")
+            ]
+        )
 
     @http.route('/contacto/enviar', type='http', auth='public', website=True, methods=['POST'], csrf=True)
     def contacto_enviar(self, **post):

--- a/addons/teidesat_website/models/__init__.py
+++ b/addons/teidesat_website/models/__init__.py
@@ -1,0 +1,1 @@
+from . import teidesatkids_question

--- a/addons/teidesat_website/models/teidesatkids_question.py
+++ b/addons/teidesat_website/models/teidesatkids_question.py
@@ -1,0 +1,59 @@
+from odoo import models, fields
+
+
+class TeidesatKidsQuestion(models.Model):
+    _name = "teidesat.kids.question"
+    _description = "Pregunta del minijuego TeidesatKids"
+    _order = "sequence, id"
+
+    sequence = fields.Integer(string="Orden", default=10)
+
+    name = fields.Char(
+        string="Pregunta",
+        required=True
+    )
+
+    answer_1 = fields.Char(
+        string="Respuesta 1",
+        required=True
+    )
+
+    answer_2 = fields.Char(
+        string="Respuesta 2",
+        required=True
+    )
+
+    answer_3 = fields.Char(
+        string="Respuesta 3",
+        required=True
+    )
+
+    correct_answer = fields.Selection(
+        [
+            ("0", "Respuesta 1"),
+            ("1", "Respuesta 2"),
+            ("2", "Respuesta 3"),
+        ],
+        string="Respuesta correcta",
+        required=True,
+        default="0"
+    )
+
+    active = fields.Boolean(
+        string="Activa",
+        default=True
+    )
+
+    category = fields.Char(
+        string="Categoría"
+    )
+
+    difficulty = fields.Selection(
+        [
+            ("easy", "Fácil"),
+            ("medium", "Media"),
+            ("hard", "Difícil"),
+        ],
+        string="Dificultad",
+        default="easy"
+    )

--- a/addons/teidesat_website/security/ir.model.access.csv
+++ b/addons/teidesat_website/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_teidesat_kids_question_user,access.teidesat.kids.question.user,model_teidesat_kids_question,base.group_user,1,1,1,1

--- a/addons/teidesat_website/static/src/js/teidesatkids_game.js
+++ b/addons/teidesat_website/static/src/js/teidesatkids_game.js
@@ -164,7 +164,7 @@ function initTeidesatKidsGame() {
 
     const questionOptionAreas = [];
 
-    const scienceQuestions = [
+    let scienceQuestions = [
         {
             question: "¿Qué es un nanosatélite?",
             options: ["Un satélite pequeño", "Un planeta pequeño", "Una estrella"],
@@ -216,6 +216,43 @@ function initTeidesatKidsGame() {
             correct: 0
         }
     ];
+
+    async function loadQuestionsFromOdoo() {
+        try {
+            const response = await fetch("/teidesatkids/questions");
+
+            if (!response.ok) {
+                throw new Error("Respuesta no válida del servidor");
+            }
+
+            const questions = await response.json();
+
+            if (Array.isArray(questions) && questions.length > 0) {
+                scienceQuestions = questions;
+                console.log("Preguntas cargadas desde Odoo:", scienceQuestions.length);
+            }
+        } catch (error) {
+            console.warn(
+                "No se pudieron cargar preguntas desde Odoo. Se usan preguntas por defecto.",
+                error
+            );
+        }
+    }
+
+    function shuffleQuestion(question) {
+        const options = question.options.map((text, index) => ({
+            text,
+            isCorrect: index === question.correct
+        }));
+
+        options.sort(() => Math.random() - 0.5);
+
+        return {
+            question: question.question,
+            options: options.map(option => option.text),
+            correct: options.findIndex(option => option.isCorrect)
+        };
+    }
 
     const stars = Array.from({ length: 50 }, () => ({
         x: Math.random() * GAME_WIDTH,
@@ -338,7 +375,10 @@ function initTeidesatKidsGame() {
         rescueUsed = true;
         rescueCause = cause;
         waitingForAnswer = true;
-        pendingQuestion = scienceQuestions[Math.floor(Math.random() * scienceQuestions.length)];
+        const selectedQuestion =
+            scienceQuestions[Math.floor(Math.random() * scienceQuestions.length)];
+
+        pendingQuestion = shuffleQuestion(selectedQuestion);
 
         keys.up = false;
         keys.down = false;
@@ -1428,7 +1468,7 @@ function initTeidesatKidsGame() {
 
         window.__teidesatKidsOrientationBound = true;
     }
-
+    loadQuestionsFromOdoo();
     resetGame();
 }
 

--- a/addons/teidesat_website/views/teidesatkids_question_views.xml
+++ b/addons/teidesat_website/views/teidesatkids_question_views.xml
@@ -1,0 +1,52 @@
+<odoo>
+
+    <record id="view_teidesat_kids_question_tree" model="ir.ui.view">
+        <field name="name">teidesat.kids.question.tree</field>
+        <field name="model">teidesat.kids.question</field>
+        <field name="arch" type="xml">
+            <tree string="Preguntas TeidesatKids">
+                <field name="name"/>
+                <field name="active"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_teidesat_kids_question_form" model="ir.ui.view">
+        <field name="name">teidesat.kids.question.form</field>
+        <field name="model">teidesat.kids.question</field>
+        <field name="arch" type="xml">
+            <form string="Pregunta TeidesatKids">
+                <sheet>
+                    <group>
+                        <field name="active"/>
+                        <field name="name"/>
+                    </group>
+
+                    <group string="Respuestas">
+                        <field name="answer_1"/>
+                        <field name="answer_2"/>
+                        <field name="answer_3"/>
+                        <field name="correct_answer"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_teidesat_kids_questions" model="ir.actions.act_window">
+        <field name="name">Preguntas TeidesatKids</field>
+        <field name="res_model">teidesat.kids.question</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_teidesat_kids_root"
+              name="TeidesatKids"
+              sequence="80"/>
+
+    <menuitem id="menu_teidesat_kids_questions"
+              name="Preguntas"
+              parent="menu_teidesat_kids_root"
+              action="action_teidesat_kids_questions"
+              sequence="10"/>
+
+</odoo>


### PR DESCRIPTION
Se añade un sistema interno en Odoo para gestionar preguntas del minijuego TeidesatKids sin tocar directamente el JavaScript.

Cambios principales:
- Nuevo modelo Odoo `teidesat.kids.question`.
- Vista interna en Odoo para crear, editar, activar y desactivar preguntas.
- Permisos de acceso para usuarios internos.
- Ruta `/teidesatkids/questions` que devuelve las preguntas activas en formato JSON.
- Carga dinámica de preguntas desde el JavaScript del minijuego.
- Se mantienen preguntas por defecto en el JS como respaldo si no se pueden cargar preguntas desde Odoo.

Pruebas realizadas:
- Creación de pregunta desde la interfaz interna de Odoo.
- Comprobación de la ruta JSON `/teidesatkids/questions`.
- Comprobación de carga desde el minijuego TeidesatKids.